### PR TITLE
Set timezones to UTC in Grafana and Graphite

### DIFF
--- a/metrics/templates/grafana/config.js
+++ b/metrics/templates/grafana/config.js
@@ -47,7 +47,7 @@ function (Settings) {
      *   If TIME_ZONE is set to UTC, set this to "0000"
      */
 
-    timezoneOffset: null,
+    timezoneOffset: "0000",
 
     grafana_index: "grafana-dash",
 

--- a/metrics/templates/graphite/local_settings.py
+++ b/metrics/templates/graphite/local_settings.py
@@ -22,7 +22,7 @@ ALLOWED_HOSTS = ['*']
 # Set your local timezone (Django's default is America/Chicago)
 # If your graphs appear to be offset by a couple hours then this probably
 # needs to be explicitly set to your local timezone.
-#TIME_ZONE = 'America/Los_Angeles'
+TIME_ZONE = 'UTC'
 
 # Override this to provide documentation specific to your Graphite deployment
 #DOCUMENTATION_URL = "http://graphite.readthedocs.org/"


### PR DESCRIPTION
Without this fix when you try to zoom in by dragging on the map you
_always_ end up with no data displayed no matter how big the zoom is.

This doesn't affect the times displayed in the grafana browser - it still uses
browser timezone offset to correct things.
