### PR TITLE
Use port from request and scheme-relative for ElasticSearch and Graphite URLs

### DIFF
--- a/metrics/map.jinja
+++ b/metrics/map.jinja
@@ -1,8 +1,8 @@
 {% set grafana = salt['grains.filter_by']({
     'Debian': {
         'revision': 'v1.5.3',
-        'elasticsearchUrl': 'http://"+window.location.hostname.replace(/^grafana/,"elasticsearch")+":8080',
-        'graphiteUrl': 'http://"+window.location.hostname.replace(/^grafana/,"graphite")+":8080'
+        'elasticsearchUrl': '//"+window.location.hostname.replace(/^grafana/,"elasticsearch")+(window.location.port ? ":" + window.location.port : "")+"',
+        'graphiteUrl': '//"+window.location.hostname.replace(/^grafana/,"graphite")+(window.location.port ? ":" + window.location.port : "")+"',
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('grafana', {})) %}


### PR DESCRIPTION
Use the port from the URL, and scheme-relative url to pick up the right http/https from the request
