### PR TITLE
Set a sensible default retention/aggregation policy; enable auto-resize on carbon start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version x.x.x
+
+* Increase & synchronise resolution of graphite and collectd
+
 ## Version 1.2.2
 
 * Add extra upstart job to correctly create run dirs for graphite at startup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Version x.x.x
 
 * Increase & synchronise resolution of graphite and collectd
+* Automatically resize whisper databases on carbon restart, if necessary.
 
 ## Version 1.2.2
 

--- a/metrics/files/graphite/carbon.conf
+++ b/metrics/files/graphite/carbon.conf
@@ -4,9 +4,14 @@ description "carbon daemon"
 
 start on (local-filesystems and net-device-up IFACE!=lo)
 
-env PATH=/usr/local/bin/:/usr/local/sbin:/bin:/usr/sbin:/usr/bin:/sbin
+env PATH=/srv/graphite/virtualenv/bin:/usr/local/bin/:/usr/local/sbin:/bin:/usr/sbin:/usr/bin:/sbin
 setuid graphite
 chdir /srv/graphite
+
+pre-start script
+  /srv/graphite/bin/update_whisper_files_if_config_changed
+end script
+
 exec /srv/graphite/bin/carbon-cache.py --debug start >>/var/log/graphite/carbon-supervisor.out 2>>/var/log/graphite/carbon-supervisor.err
 
 ## Try to restart up to 10 times within 5 min:

--- a/metrics/files/graphite/conf/carbon.conf
+++ b/metrics/files/graphite/conf/carbon.conf
@@ -281,7 +281,7 @@ USE_FLOW_CONTROL = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 
 
 [aggregator]
@@ -356,4 +356,4 @@ MAX_AGGREGATION_INTERVALS = 5
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10

--- a/metrics/files/graphite/conf/carbon.conf
+++ b/metrics/files/graphite/conf/carbon.conf
@@ -164,7 +164,7 @@ WHISPER_FALLOCATE_CREATE = True
 # metricsReceived) with the top level prefix of 'carbon' at an interval of 60
 # seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
 # CARBON_METRIC_PREFIX = carbon
-# CARBON_METRIC_INTERVAL = 60
+CARBON_METRIC_INTERVAL = 10
 
 # Enable AMQP if you want to receve metrics using an amqp broker
 # ENABLE_AMQP = False

--- a/metrics/files/graphite/conf/storage-aggregation.conf
+++ b/metrics/files/graphite/conf/storage-aggregation.conf
@@ -28,5 +28,5 @@ aggregationMethod = sum
 
 [default_average]
 pattern = .*
-xFilesFactor = 0.5
+xFilesFactor = 0.0
 aggregationMethod = average

--- a/metrics/files/graphite/conf/storage-schemas.conf
+++ b/metrics/files/graphite/conf/storage-schemas.conf
@@ -14,5 +14,5 @@
 # a reasonable default strategy
 [default]
 pattern = .*
-retentions = 5s:1h,1m:1d,5m:7d,30m:30d,1h:1y
+retentions = 10s:1h,1m:1d,5m:7d,30m:30d,1h:1y
 

--- a/metrics/files/graphite/conf/storage-schemas.conf
+++ b/metrics/files/graphite/conf/storage-schemas.conf
@@ -11,8 +11,14 @@
 #pattern = ^carbon\.
 #retentions = 10s:4h,1m:1d,5m:7d,30m:30d,1h:1y
 
-# a reasonable default strategy
+# Per-fragment datapoints:     {"10s:10d"=>86400, "5m:400d"=>115200, "24h:20y"=>7300}
+# Size per metric:             2448KiB
+#
+# For 20 hosts with avg 1000 metrics per host:
+# Datapoints recd per second:  2000
+# Total disk space needed:     47813MiB
+# 
 [default]
 pattern = .*
-retentions = 10s:4h,1m:1d,5m:7d,30m:30d,1h:1y
+retentions = 10s:10d,5m:400d,24h:20y
 

--- a/metrics/files/graphite/conf/storage-schemas.conf
+++ b/metrics/files/graphite/conf/storage-schemas.conf
@@ -14,5 +14,5 @@
 # a reasonable default strategy
 [default]
 pattern = .*
-retentions = 10s:1h,1m:1d,5m:7d,30m:30d,1h:1y
+retentions = 10s:4h,1m:1d,5m:7d,30m:30d,1h:1y
 

--- a/metrics/files/graphite/conf/storage-schemas.conf
+++ b/metrics/files/graphite/conf/storage-schemas.conf
@@ -5,12 +5,6 @@
 #  pattern = regex
 #  retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
 
-# Carbon's internal metrics. This entry should match what is specified in
-# CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
-#[carbon]
-#pattern = ^carbon\.
-#retentions = 10s:4h,1m:1d,5m:7d,30m:30d,1h:1y
-
 # Per-fragment datapoints:     {"10s:10d"=>86400, "5m:400d"=>115200, "24h:20y"=>7300}
 # Size per metric:             2448KiB
 #

--- a/metrics/files/graphite/conf/storage-schemas.conf
+++ b/metrics/files/graphite/conf/storage-schemas.conf
@@ -7,10 +7,12 @@
 
 # Carbon's internal metrics. This entry should match what is specified in
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
-[carbon]
-pattern = ^carbon\.
-retentions = 60:90d
+#[carbon]
+#pattern = ^carbon\.
+#retentions = 60s:90d
 
-[default_1min_for_1day]
+# a reasonable default strategy
+[default]
 pattern = .*
-retentions = 60s:1d
+retentions = 5s:1h,1m:1d,5m:7d,30m:30d,1h:1y
+

--- a/metrics/files/graphite/conf/storage-schemas.conf
+++ b/metrics/files/graphite/conf/storage-schemas.conf
@@ -9,7 +9,7 @@
 # CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
 #[carbon]
 #pattern = ^carbon\.
-#retentions = 60s:90d
+#retentions = 10s:4h,1m:1d,5m:7d,30m:30d,1h:1y
 
 # a reasonable default strategy
 [default]

--- a/metrics/files/graphite/contrib/update_whisper_files_if_config_changed
+++ b/metrics/files/graphite/contrib/update_whisper_files_if_config_changed
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+DB_BASE="/srv/graphite/storage/whisper"
+CONF_BASE="/srv/graphite/conf"
+CARBON_CONF="${CONF_BASE}/carbon.conf"
+STORAGE_SCHEMAS_CONF="${CONF_BASE}/storage-schemas.conf"
+STORAGE_AGGREGATION_CONF="${CONF_BASE}/storage-aggregation.conf"
+AUTO_RESIZE="/srv/graphite/virtualenv/bin/whisper-auto-resize.py"
+
+FLAG_FILE="${DB_BASE}/.update_whisper_files_if_config_changed.LAST_RESIZE_RUN"
+
+E_MISSING_REQ=2
+E_RESIZE_FAILED=3
+
+if [[ ! -d $DB_BASE ]]; then
+  echo "FATAL: whisper db dir ${DB_BASE} is not present"
+  exit $E_MISSING_REQ
+fi
+
+if [[ ! -f $STORAGE_SCHEMAS_CONF ]]; then
+  echo "FATAL: conf file ${STORAGE_SCHEMAS_CONF} is not present"
+  exit $E_MISSING_REQ
+fi
+
+if [[ ! -f $STORAGE_AGGREGATION_CONF ]]; then
+  echo "FATAL: conf file ${STORAGE_AGGREGATION_CONF} is not present"
+  exit $E_MISSING_REQ
+fi
+
+if [[ ! -f $CARBON_CONF ]]; then
+  echo "FATAL: conf file ${CARBON_CONF} is not present"
+  exit $E_MISSING_REQ
+fi
+
+if [[ ! -f $AUTO_RESIZE ]]; then
+  echo "FATAL: missing file ${AUTO_RESIZE}"
+  exit $E_MISSING_REQ
+fi
+
+run_resize=0
+if [[ -f $FLAG_FILE ]]; then
+  if [[ $CARBON_CONF -nt $FLAG_FILE ]]; then
+    run_resize=1
+  elif [[ $STORAGE_SCHEMAS_CONF -nt $FLAG_FILE ]]; then
+    run_resize=1
+  elif [[ $STORAGE_AGGREGATION_CONF -nt $FLAG_FILE ]]; then
+    run_resize=1
+  fi
+else
+  run_resize=1
+fi
+
+if [[ $run_resize == 1 ]]; then
+  $AUTO_RESIZE --doit --quiet $DB_BASE $CONF_BASE
+  if [[ $? == 0 ]]; then
+    touch $FLAG_FILE
+  else
+    echo "FATAL: $AUTO_RESIZE failed!"
+    exit $E_RESIZE_FAIL
+  fi
+fi
+

--- a/metrics/files/graphite/contrib/whisper-auto-resize.py
+++ b/metrics/files/graphite/contrib/whisper-auto-resize.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+import sys, os, fnmatch
+from subprocess import call
+from optparse import OptionParser
+
+option_parser = OptionParser(
+    usage='''%prog storagePath configPath
+
+storagePath   the Path to the directory containing whisper files (CAN NOT BE A SUBDIR, use --subdir for that)
+configPath    the path to your carbon config files
+''', version="%prog 0.1")
+
+option_parser.add_option(
+    '--doit', default=False, action='store_true',
+    help="This is not a drill, lets do it")
+option_parser.add_option(
+    '-q', '--quiet', default=False, action='store_true',
+    help="Display extra debugging info")
+option_parser.add_option(
+    '--subdir', default=None,
+    type='string', help="only process a subdir of whisper files")
+option_parser.add_option(
+    '--carbonlib', default=None,
+    type='string', help="folder where the carbon lib files are if its not in your path already")
+option_parser.add_option(
+    '--whisperlib', default=None,
+    type='string', help="folder where the whisper lib files are if its not in your path already")
+option_parser.add_option(
+    '--confirm', default=False, action='store_true',
+    help="ask for comfirmation prior to resizing a whisper file")
+option_parser.add_option(
+    '-x', '--extra_args', default='',
+    type='string', help="pass any additional arguments to the whisper-resize.py script")
+
+(options, args) = option_parser.parse_args()
+
+if len(args) < 2:
+    option_parser.print_help()
+    sys.exit(1)
+
+storagePath = args[0]
+configPath  = args[1]
+
+#check to see if we are processing a subfolder
+# we need to have a seperate config option for this since
+# otherwise the metric test thinks the metric is at the root
+# of the storage path and can match schemas incorrectly
+if options.subdir is None:
+    processPath = args[0]
+else:
+    processPath = options.subdir
+
+# Injecting the Whisper Lib Path if needed
+if options.whisperlib is not None:
+    sys.path.insert(0, options.whisperlib)
+
+try:
+    import whisper
+except ImportError:
+    raise SystemExit('[ERROR] Can\'t find the whisper module, try using --whisperlib to explicitly include the path')
+
+# Injecting the Carbon Lib Path if needed
+if options.carbonlib is not None:
+    sys.path.insert(0, options.carbonlib)
+
+try:
+    from carbon import conf
+    from carbon.conf import settings
+except ImportError:
+    raise SystemExit('[ERROR] Can\'t find the carbon module, try using --carbonlib to explicitly include the path')
+
+#carbon.conf not seeing the config files so give it a nudge
+settings.CONF_DIR = configPath
+settings.LOCAL_DATA_DIR = storagePath
+
+# import these once we have the settings figured out
+from carbon.storage import loadStorageSchemas, loadAggregationSchemas
+
+# Load the Defined Schemas from our config files
+schemas = loadStorageSchemas()
+agg_schemas = loadAggregationSchemas()
+
+# check to see if a metric needs to be resized based on the current config
+def processMetric(fullPath, schemas, agg_schemas):
+    """
+        method to process a given metric, and resize it if necessary
+
+        Parameters:
+            fullPath    - full path to the metric whisper file
+            schemas     - carbon storage schemas loaded from config
+            agg_schemas - carbon storage aggregation schemas load from confg
+
+    """
+    schema_config_args = ''
+    schema_file_args   = ''
+    rebuild = False
+    messages = ''
+
+    # get archive info from whisper file
+    info = whisper.info(fullpath)
+
+    # get graphite metric name from fullPath
+    metric = getMetricFromPath(fullpath)
+
+    # loop the carbon-storage schemas
+    for schema in schemas:
+        if schema.matches(metric):
+            # returns secondsPerPoint and points for this schema in tuple format
+            archive_config = [archive.getTuple() for archive in schema.archives]
+            break
+
+    # loop through the carbon-aggregation schemas
+    for agg_schema in agg_schemas:
+        if agg_schema.matches(metric):
+            xFilesFactor, aggregationMethod = agg_schema.archives
+            break
+
+    # loop through the bucket tuples and convert to string format for resizing
+    for retention in archive_config:
+        current_schema = '%s:%s ' % (retention[0], retention[1])
+        schema_config_args += current_schema
+
+    # loop through the current files bucket sizes and convert to string format to compare for resizing
+    for fileRetention in info['archives']:
+        current_schema  = '%s:%s ' % (fileRetention['secondsPerPoint'], fileRetention['points'])
+        schema_file_args += current_schema
+
+    # check to see if the current and configured schemas are the same or rebuild
+    if (schema_config_args != schema_file_args):
+        rebuild = True
+        messages += 'updating Retentions from: %s to: %s \n' % (schema_file_args, schema_config_args)
+
+    # only care about the first two decimals in the comparison since there is floaty stuff going on.
+    info_xFilesFactor = "{0:.2f}".format(info['xFilesFactor'])
+    str_xFilesFactor =  "{0:.2f}".format(xFilesFactor)
+
+    # check to see if the current and configured aggregationMethods are the same
+    if (str_xFilesFactor != info_xFilesFactor):
+        rebuild = True
+        messages += '%s xFilesFactor differs real: %s should be: %s \n' % (metric, info_xFilesFactor, str_xFilesFactor)
+    if (aggregationMethod != info['aggregationMethod']):
+        rebuild = True
+        messages += '%s aggregation schema differs real: %s should be: %s \n' % (metric, info['aggregationMethod'], aggregationMethod)
+
+    # check to see if the current and configured xFilesFactor are the same
+    if (xFilesFactor != info['xFilesFactor']):
+        rebuild = True
+        messages += '%s xFilesFactor differs real: %s should be: %s \n' % (metric, info['xFilesFactor'], xFilesFactor)
+
+    # if we need to rebuild, lets do it.
+    if (rebuild == True):
+        cmd = 'whisper-resize.py %s %s --xFilesFactor=%s --aggregationMethod=%s %s' % (fullPath, options.extra_args, xFilesFactor, aggregationMethod, schema_config_args)
+        if (options.quiet != True or options.confirm == True):
+            print messages
+            print cmd
+
+        if (options.confirm == True):
+            options.doit = confirm("Would you like to run this command? [y/n]: ")
+            if (options.doit == False):
+                print "Skipping command \n"
+
+        if (options.doit == True):
+            exitcode = call(cmd, shell=True)
+            # if the command failed lets bail so we can take a look before proceeding
+            if (exitcode > 0):
+                print 'Error running: %s' % (cmd)
+                sys.exit(1)
+
+def getMetricFromPath(filePath):
+    """
+        this method takes the full file path of a whisper file an converts it to a gaphite metric name
+
+        Parameters:
+            filePath - full file path to a whisper file
+
+        Returns a string representing the metric name
+    """
+    # sanitize directory since we may get a trailing slash or not, and if we don't it creates a leading .
+    data_dir = os.path.normpath(settings.LOCAL_DATA_DIR) + os.sep
+
+    # pull the data dir off and convert to the graphite metric name
+    metric_name = filePath.replace(data_dir, '')
+    metric_name = metric_name.replace('.wsp', '')
+    metric_name = metric_name.replace('/', '.')
+    return metric_name
+
+def confirm(question, error_response='Valid options : yes or no'):
+    """
+         ask the user if they would like to perform the action
+
+         Parameters:
+             question       - the question you would like to ask the user to confirm.
+             error_response - the message to display if an invalid option is given.
+    """
+    while True:
+        answer = raw_input(question).lower()
+        if answer in ('y', 'yes'):
+            return True
+        if answer in ('n', 'no' ):
+            return False
+        print error_response
+
+for root, _, files in os.walk(processPath):
+    # we only want to deal with non-hidden whisper files
+    for f in fnmatch.filter(files, '*.wsp'):
+        fullpath = os.path.join(root, f)
+        processMetric(fullpath, schemas, agg_schemas)
+

--- a/metrics/files/graphite/contrib/whisper-auto-resize.py
+++ b/metrics/files/graphite/contrib/whisper-auto-resize.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+#
+# This file is included from the contrib/ directory in 
+# https://github.com/graphite-project/whisper
+#
+# Specifically, https://github.com/graphite-project/whisper/blob/e0e06c0dfbc9b4d6c90ed6662bd87dfa9edd5413/contrib/whisper-auto-resize.py
+# 
+
 import sys, os, fnmatch
 from subprocess import call
 from optparse import OptionParser

--- a/metrics/graphite.sls
+++ b/metrics/graphite.sls
@@ -35,6 +35,16 @@ graphite_virtualenv:
     - require_in:
       - service: graphite-service
 
+/srv/graphite/virtualenv/bin/whisper-auto-resize.py:
+  file:
+    - managed
+    - source: salt://metrics/files/graphite/contrib/whisper-auto-resize.py
+    - user: root
+    - group: graphite
+    - mode: 0755
+    - require:
+      - cmd: graphite_virtualenv
+
 # pycairo is crazy to build - avoid - so we rely on system-site-packages
 # two lines require specific pip arguments
 

--- a/metrics/graphite.sls
+++ b/metrics/graphite.sls
@@ -45,6 +45,14 @@ graphite_virtualenv:
     - require:
       - cmd: graphite_virtualenv
 
+/srv/graphite/bin/update_whisper_files_if_config_changed:
+  file:
+    - managed
+    - source: salt://metrics/files/graphite/contrib/update_whisper_files_if_config_changed
+    - user: root
+    - group: graphite
+    - mode: 0755
+
 # pycairo is crazy to build - avoid - so we rely on system-site-packages
 # two lines require specific pip arguments
 
@@ -135,6 +143,8 @@ graphite_seed:
     - user: root
     - group: root
     - mode: 644
+    - require:
+      - file: /srv/graphite/bin/update_whisper_files_if_config_changed
 
 graphite-service:
   service.running:

--- a/metrics/templates/collectd/collectd.conf
+++ b/metrics/templates/collectd/collectd.conf
@@ -1,7 +1,6 @@
 {% from 'metrics/map.jinja' import collectd with context %}
 
 FQDNLookup true
-Interval 5
 
 LoadPlugin syslog
 LoadPlugin battery

--- a/metrics/templates/collectd/collectd.conf
+++ b/metrics/templates/collectd/collectd.conf
@@ -1,6 +1,7 @@
 {% from 'metrics/map.jinja' import collectd with context %}
 
 FQDNLookup true
+Interval 3
 
 LoadPlugin syslog
 LoadPlugin battery

--- a/metrics/templates/collectd/collectd.conf
+++ b/metrics/templates/collectd/collectd.conf
@@ -1,7 +1,7 @@
 {% from 'metrics/map.jinja' import collectd with context %}
 
 FQDNLookup true
-Interval 3
+Interval 5
 
 LoadPlugin syslog
 LoadPlugin battery


### PR DESCRIPTION
This PR improves our Graphite installations to keep a healthy amount of data for long periods:
- 10s resolution for 10 days (collectd/statsd update interval), so we don't lose resolution on most of our use cases.
- 5m for 400 days - reasonable accuracy for long-term data.
- 24hr for 20 years - so we don't throw away data.

In the process, ensure that we resize our whisper db files automatically if the configuration changes. A small delay on starting up carbon is better than writing to the wrong format db file.

Note that this could increase the size of your Graphite storage/whisper data considerably. It is worth doing a count of the number of whisper files in there, you will need 2.5MiB for each one after resize.

```
# size required in KB:
echo $(( $(find /srv/graphite/storage/whisper/ -name \*.wsp | wc -l) * 2500 ))
```
