### PR TITLE
Use 'set -e' in bootstrap helpers.

### DIFF
--- a/metrics/files/graphite/graphite_seed.sh
+++ b/metrics/files/graphite/graphite_seed.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 ${HOME}/virtualenv/bin/python graphite/manage.py syncdb --noinput
 ${HOME}/virtualenv/bin/python graphite/manage.py loaddata ${HOME}/conf/graphite_seed.json
 ${HOME}/virtualenv/bin/python graphite/manage.py collectstatic --noinput

--- a/metrics/files/graphite/requirements.sh
+++ b/metrics/files/graphite/requirements.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 cd ${HOME}
 virtualenv --system-site-packages virtualenv
 source virtualenv/bin/activate


### PR DESCRIPTION
The salt bootstrapping helpers would touch their 'flag file' regardless
of the actual success/failure of their subcommands. This masked some
pretty ugly failures, as salt would subsequently skip them in later
runs.
