### PR TITLE
Explicitly manage /srv/graphite/storage perms

### DIFF
--- a/metrics/graphite.sls
+++ b/metrics/graphite.sls
@@ -70,6 +70,14 @@ graphite_virtualenv:
       - service: graphite-service
       - service: carbon
 
+/srv/graphite/storage:
+  file:
+    - directory
+    - user: graphite
+    - group: graphite
+    - require:
+      - user: graphite
+
 /srv/graphite/storage/log/webapp:
   file:
     - directory
@@ -78,6 +86,7 @@ graphite_virtualenv:
     - makedirs: True
     - require:
       - user: graphite
+      - file: /srv/graphite/storage
 
 graphite_seed:
   cmd:


### PR DESCRIPTION
This has stemmed out of the Vagrant setup i'm doing for the
monitoring system -- previously /srv/graphite/storage would be
automatically created with the right perms. Now we need to account
for it possibly being there before we start - with incorrect ownership.
