### PR TITLE
Prepare for 14.04 - do not pin collectd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Versoin 1.4.0
+# CURRENT
+
+* Support deployment to Ubuntu 14.04.
+
+# Version 1.4.0
 
 * Ask statsd plugin to create derived metrics for timers `*-count`,
   `*-percentile-50`, `*-percentile-95`, and upper and lower bounds.

--- a/metrics/collectd.sls
+++ b/metrics/collectd.sls
@@ -5,13 +5,17 @@ include:
 
 collectd-core:
   pkg.installed:
+{% if collectd.revision %}
     - version: {{ collectd.revision }}
+{% endif %}
     - watch_in:
       - service: collectd
 
 collectd:
   pkg.installed:
+{% if collectd.revision %}
     - version: {{ collectd.revision }}
+{% endif %}
     - watch_in:
       - service: collectd
   service:

--- a/metrics/map.jinja
+++ b/metrics/map.jinja
@@ -16,12 +16,15 @@
 
 
 {% set collectd = salt['grains.filter_by']({
-    'Debian': {
+    'Ubuntu-12.04': {
         'carbon': 'monitoring.local',
         'revision': '5.4.0-ppa1~precise1'
     },
-    'default': 'Debian',
-}, merge=salt['pillar.get']('collectd',{})) %}
+    'default': {
+        'carbon': 'monitoring.local',
+        'revision': False
+    },
+}, grain='osfinger', merge=salt['pillar.get']('collectd',{})) %}
 
 
 {% set beaver = salt['grains.filter_by']({


### PR DESCRIPTION
The previous collectd pinning was purely for 12.04. Make our default case to not pin the version.
