### PR TITLE
Updating mixlib-shellout gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       test-kitchen (~> 1.0)
     mime-types (2.4.3)
     mini_portile (0.6.1)
-    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.1)
     multi_json (1.10.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)


### PR DESCRIPTION
This was causing all builds to fail. Some genius ripped out publicly available mixlib-shellout gem version from rubygems so bundle install was failing as Gemfile.lock was pinning the gem to a particular version which was no longer available due to ^^.
