### PR TITLE
Fix to allow collectd.prefix on 14.04 and non-12.04 Ubuntu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.5.1
+
+* Fix to allow collectd.prefix on 14.04 and non-12.04 Ubuntu.
+
 # Version 1.5.0
 
 * Allow collectd graphite prefix to be set via collectd.prefix

--- a/metrics/map.jinja
+++ b/metrics/map.jinja
@@ -24,7 +24,8 @@
     },
     'default': {
         'carbon': 'monitoring.local',
-        'revision': False
+        'revision': False,
+        'prefix': None,
     },
 }, grain='osfinger', merge=salt['pillar.get']('collectd',{})) %}
 


### PR DESCRIPTION
Add missing default from map.jinja to give a default value on Trusty.
