### PR TITLE
Let's prevent collectd from memory leaking when graphite is down.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.6.?
+
+* Prevent collectd from buffering metrics when graphite is not accessible
+
 # Version 1.6.0
 
 * Allow specification of graphite.data_dir (default /srv/graphite/storage)

--- a/metrics/files/graphite/conf/carbon.conf
+++ b/metrics/files/graphite/conf/carbon.conf
@@ -74,7 +74,7 @@ LINE_RECEIVER_PORT = 2003
 # Set this to True to enable the UDP listener. By default this is off
 # because it is very common to run multiple carbon daemons and managing
 # another (rarely used) port for every carbon instance is not fun.
-ENABLE_UDP_LISTENER = False
+ENABLE_UDP_LISTENER = True
 UDP_RECEIVER_INTERFACE = 0.0.0.0
 UDP_RECEIVER_PORT = 2003
 

--- a/metrics/graphite.sls
+++ b/metrics/graphite.sls
@@ -201,6 +201,7 @@ carbon:
       - file: /etc/apparmor.d/nginx_local
 
 {% from 'firewall/lib.sls' import firewall_enable with context %}
-{{ firewall_enable('graphite', 2003, proto='tcp') }}
-{{ firewall_enable('graphite', 2004, proto='tcp') }}
-{{ firewall_enable('graphite', 7002, proto='tcp') }}
+{{ firewall_enable('graphite-tcp', 2003, proto='tcp') }}
+{{ firewall_enable('graphite-udp', 2003, proto='udp') }}
+{{ firewall_enable('graphite-pickle', 2004, proto='tcp') }}
+{{ firewall_enable('graphite-cache', 7002, proto='tcp') }}

--- a/metrics/templates/collectd/collectd.conf
+++ b/metrics/templates/collectd/collectd.conf
@@ -42,7 +42,7 @@ LoadPlugin "write_graphite"
    Prefix "metrics."
 {%- endif %}
    #Postfix ""
-   Protocol "tcp"
+   Protocol "udp"
    EscapeCharacter "."
    SeparateInstances true
    StoreRates true


### PR DESCRIPTION
Solves #34 by configuring transport between collectd and graphite as UDP. That way metric will be always sent. It won't be buffered within collectd.
It happens for the price of not guaranteeing the delivery.

Long term we should introduce limited buffering within collectd.
See: WriteQueueLengthLimitHigh
At the moment (Collectd 5.4) WriteQueueLengthLimitHigh functionality has not been yet officially released.

See:
write_graphite: Possible memory leak
https://github.com/collectd/collectd/issues/359

Add a limit to the write queue length before dropping packets.
https://github.com/collectd/collectd/pull/280
