### PR TITLE
Install bucky on monitoring server and bind it to port 8126 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ nosetests.xml
 .kitchen.local.yml
 .bundle
 vendor
+*~
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version 1.6.?
 
 * Prevent collectd from buffering metrics when graphite is not accessible
+* Install bucky on monitoring server and bind it to port 8126
 
 # Version 1.6.0
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,21 @@ Usage
 
 You shouldn't use this formula directly unless you know what you are doing.  If you want to set up monitoring on your servers you should look at the monitoring formula.
 
-Install and configure graphite, collectd and statsd (via bucky) and grafana
+Install and configure graphite, collectd, bucky and grafana.
+
+There are two statsd interfaces provided.
+
+Firstly, on each host we install collectd with statsd intefrace exposed (default port 8125).
+Keys for metrics reported there will be prefixed with "metric.hostname.type".
+So use it only to store host specific metrics.
+
+Secondly, in case you need host independent, aggregated metrics
+i.e. you want to report data from application scaled horizontally behind loadbalancer,
+than use a central metrics endpoint. It's by default located on host: `monitoring.local` and port 8126.
+This functionality is provided by bucky.
+
+
+Collectd exposes
 
 .. note::
 

--- a/metrics/files/statsd/requirements.txt
+++ b/metrics/files/statsd/requirements.txt
@@ -1,2 +1,3 @@
-bucky
+bucky==2.2.2
 gunicorn
+setproctitle

--- a/metrics/map.jinja
+++ b/metrics/map.jinja
@@ -18,6 +18,15 @@
 }, merge=salt['pillar.get']('graphite',{})) %}
 
 
+{% set bucky = salt['grains.filter_by']({
+    'Debian': {
+        'carbon': 'localhost',
+        'port': 8126,
+    },
+    'default': 'Debian',
+}, merge=salt['pillar.get']('bucky',{})) %}
+
+
 {% set collectd = salt['grains.filter_by']({
     'Ubuntu-12.04': {
         'carbon': 'monitoring.local',

--- a/metrics/server.sls
+++ b/metrics/server.sls
@@ -4,3 +4,4 @@ include:
   - .graphite
   - .collectd
   - .grafana
+  - .statsd

--- a/metrics/statsd.sls
+++ b/metrics/statsd.sls
@@ -1,0 +1,55 @@
+{% from 'supervisor/lib.sls' import supervise with context %}
+{% from 'utils/apps/lib.sls' import app_skeleton with context %}
+{% from 'metrics/map.jinja' import bucky with context %}
+
+include:
+  - .deps
+  - python
+  - supervisor
+  - nginx
+  - .collectd
+  - firewall
+
+#bucky requires collectd types.db
+{{ app_skeleton('statsd') }}
+
+
+/srv/statsd/virtualenv:
+  virtualenv:
+    - managed
+    - venv_bin: /usr/local/bin/virtualenv
+    - system_site_packages: False
+    - requirements: salt://metrics/files/statsd/requirements.txt
+    - require:
+      - pkg: collectd-utils
+
+
+/srv/statsd/conf:
+  file:
+    - directory
+    - user: statsd
+    - group: statsd
+  require:
+    - user: statsd
+
+
+/srv/statsd/conf/bucky.conf:
+  file:
+    - managed
+    - template: jinja
+    - source: salt://metrics/templates/statsd/bucky.conf
+    - require:
+      - file: /srv/statsd/conf
+    - watch_in:
+      - service: supervisord
+
+
+{{ supervise('statsd',
+             cmd="/srv/statsd/virtualenv/bin/bucky",
+             args="/srv/statsd/conf/bucky.conf",
+             numprocs=1,
+             supervise=True) }}
+
+{% from 'firewall/lib.sls' import firewall_enable with  context %}
+{{ firewall_enable('statsd-bucky', bucky.port, proto='udp') }}
+{{ firewall_enable('statsd-collectd-listener', 25826,proto='udp') }}

--- a/metrics/templates/statsd/bucky.conf
+++ b/metrics/templates/statsd/bucky.conf
@@ -9,9 +9,9 @@ log_level = "INFO"
 full_trace = False
 
 # Basic metricsd conifguration
-metricsd_ip = "0.0.0.0"
+metricsd_ip = "127.0.0.1"
 metricsd_port = 23632
-metricsd_enabled = True
+metricsd_enabled = False
 
 # The default interval between flushes of metric data to Graphite
 metricsd_default_interval = 10.0
@@ -43,13 +43,32 @@ collectd_converters = {}
 # used to define converters is 'bucky.collectd.converters'.
 collectd_use_entry_points = True
 
+# Cryptographic settings for collectd. Security level 1 requires
+# signed packets, level 2 requires encrypted communication.
+# Auth file should contain lines in the form 'user: password'
+collectd_security_level = 0
+collectd_auth_file = None
+
 # Basic statsd configuration
 statsd_ip = "0.0.0.0"
-statsd_port = 8125
+statsd_port = {{ bucky.port }}
 statsd_enabled = True
 
 # How often stats should be flushed to Graphite.
 statsd_flush_time = 10.0
+
+# If the legacy namespace is enabled, the statsd backend uses the
+# default prefixes except for counters, which are stored directly
+# in stats.NAME for the rate and stats_counts.NAME for the
+# absolute count.  If legacy names are disabled, the prefixes are
+# configurable, and counters are stored under
+# stats.counters.{rate,count} by default.  Any prefix can be set
+# to None to skip it.
+statsd_legacy_namespace = False
+statsd_global_prefix = "bucky"
+statsd_prefix_counter = "counters"
+statsd_prefix_timer = "timers"
+statsd_prefix_gauge = "gauges"
 
 # Basic Graphite configuration
 graphite_ip = "{{ bucky.carbon }}"
@@ -59,9 +78,14 @@ graphite_port = 2003
 # will reconnect. The max reconnects applies each time a
 # disconnect is encountered and the reconnect delay is the time
 # in seconds between connection attempts. Setting max reconnects
-# to a negative number removes the limit.
+# to a negative number removes the limit. The backoff factor
+# determines how much the reconnect delay will be multiplied with
+# each reconnect round. It can be limited with a maximum after which
+# the delay will not be multiplied anymore.
 graphite_max_reconnects = 3
 graphite_reconnect_delay = 5
+graphite_backoff_factor = 1.5
+graphite_backoff_max = 60
 
 # Configuration for sending metrics to Graphite via the pickle
 # interface. Be sure to edit graphite_port to match the settings
@@ -93,3 +117,13 @@ name_strip_duplicates = True
 # be stripped from hostnames. For instance, if "company.tld"
 # were specified, the previous example would end up as "node".
 name_host_trim = []
+
+# processor is a callable that takes a (host, name, val, time)
+# tuple as input and is expected to return a tuple of the same
+# structure to forward the sample to the clients, or None to
+# drop it. processor_drop_on_error specifies if the sample is
+# dropped or forwarded to clients in case an exception is
+# raised by the processor callable.
+processor = None
+processor_drop_on_error = False
+


### PR DESCRIPTION
so that we can have host independent (no monitoring hostname in key) aggregated metrics.
Solves #15 
