### PR TITLE
statsd is now supervised by upstart

### DIFF
--- a/metrics/statsd.sls
+++ b/metrics/statsd.sls
@@ -43,12 +43,12 @@ include:
     - watch_in:
       - service: supervisord
 
-
-{{ supervise('statsd',
-             cmd="/srv/statsd/virtualenv/bin/bucky",
-             args="/srv/statsd/conf/bucky.conf",
-             numprocs=1,
-             supervise=True) }}
+/etc/init/statsd.conf:
+  file.managed:
+    - source: salt://metrics/templates/statsd/upstart-statsd.conf
+    - template: jinja
+    - require:
+        - file: /srv/statsd/conf/bucky.conf
 
 {% from 'firewall/lib.sls' import firewall_enable with  context %}
 {{ firewall_enable('statsd-bucky', bucky.port, proto='udp') }}

--- a/metrics/templates/statsd/upstart-statsd.conf
+++ b/metrics/templates/statsd/upstart-statsd.conf
@@ -1,0 +1,10 @@
+author "Milos Gajdos"
+
+description "statsd metrics aggregator"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+
+exec /srv/statsd/virtualenv/bin/bucky /srv/statsd/conf/bucky.conf
+
+## Try to restart up to 10 times within 5 min:
+respawn limit 10 300


### PR DESCRIPTION
We have encountered some hard to debug salt state dependencies so we have decided to supervise `statsd` with upstart.
