### PR TITLE
Add 'custom_metrics.js' dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Current
 
 * remove supervisor dependency
+* custom_metric.js dashboard, for displaying arbitrary graphite targets
 
 # Version 1.10.1
 

--- a/metrics/files/grafana/custom_metrics.js
+++ b/metrics/files/grafana/custom_metrics.js
@@ -1,0 +1,228 @@
+/* global _ */
+/*
+ * Grafana Scripted Dashboard to:
+ *
+ * Global accessable variables
+ * window, document, $, jQuery, ARGS, moment
+ *
+ * Return a dashboard object, or a function
+ *
+ * For async scripts, return a function, this function must take a single callback function,
+ * call this function with the dasboard object
+ *
+ * Author: Mike Pountney, Infracode Ltd
+ *
+ * Heavily inspired by work of: Anatoliy Dobrosynets, Recorded Future, Inc.
+ *
+ */
+
+// accessable variables in this scope
+var window, document, ARGS, $, jQuery, moment, kbn;
+
+var arg_from = '2h';
+
+var arg_title = "Custom Metrics";
+var arg_refresh = "1m";
+var arg_no_help = false;
+var arg_targets = "";
+
+if(!_.isUndefined(ARGS.no_help)) {
+  arg_no_help = ARGS.no_help;
+}
+
+if(!_.isUndefined(ARGS.title)) {
+  arg_title = ARGS.title;
+}
+
+if(!_.isUndefined(ARGS.refresh)) {
+  arg_refresh = ARGS.refresh;
+}
+
+if(!_.isUndefined(ARGS.targets)) {
+  arg_targets = ARGS.targets;
+}
+
+function get_all_metrics() {
+  var metrics_url = window.location.protocol + '//' + window.location.hostname.replace(/^grafana/,"graphite") + (window.location.port ? ":" + window.location.port : "") + '/metrics/index.json';
+  var res = [];
+  var req = new XMLHttpRequest();
+  req.open('GET', metrics_url, false);
+  req.send(null);
+  var obj = JSON.parse(req.responseText);
+  return obj;
+};
+
+//---------------------------------------------------------------------------------------
+
+function panel_help_text() {
+  var help_md = "### How to use this dashboard\n" +
+                "\n" +
+                "This dashboard expects a comma separated list of graphite target paths.\n" +
+                "\n" +
+                "These will typically need to be URI encoded.\n" +
+                "\n" +
+                "The graphs will then be displayed in order, as individual graphs.\n" +
+                "\n" +
+                "Arguments:\n" +
+                "\n" +
+                "* `no_help` -- omit this panel\n" +
+                "* `targets={target1},{target2},...`\n" +
+                "* `refresh={interval}` override default refresh interval of `1min`\n" +
+                ""
+
+  return {
+    title: 'Help',
+    type: 'text',
+    mode: 'markdown',
+    span: 8,
+    error: false,
+    content: help_md,
+    style: {}
+  }
+};
+
+function panel_all_metrics() {
+  var text_md = "### Available raw targets:\n" +
+                "\n" +
+                ""
+
+  all_targets = get_all_metrics();
+
+  for (var i = 0, len = all_targets.length; i < len; i++) {
+     text_md += "* [" + all_targets[i] + "](/#/dashboard/script/custom_metrics.js?targets=" + all_targets[i] + ")\n"
+  }
+
+  return {
+    title: 'Help',
+    type: 'text',
+    mode: 'markdown',
+    span: 8,
+    error: false,
+    content: text_md,
+    style: {}
+  }
+};
+
+function panel_custom_metric(title, targets){
+  return {
+    title: title,
+    type: 'graphite',
+    span: 8,
+    renderer: "flot",
+    y_formats: ["none", "none"],
+    grid: {max: null, min: 0},
+    lines: true,
+    fill: 0,
+    linewidth: 2,
+    stack: false,
+    legend: {show: true},
+    percentage: false,
+    nullPointMode: "null",
+    tooltip: {
+      value_type: "individual",
+      query_as_alias: true
+    },
+    targets: targets,
+  }
+};
+
+
+//---------------------------------------------------------------------------------------
+
+function row_help_text() {
+  return {
+    title: "Help",
+    height: '250px',
+    collapse: false,
+    panels: [
+      panel_help_text()
+    ]
+  }
+};
+
+function row_custom_metric(title, targets) {
+  return {
+    title: title,
+    height: '250px',
+    collapse: false,
+    panels: [
+      panel_custom_metric(title, targets)
+    ]
+  }
+};
+
+function row_all_metrics() {
+  return {
+    title: "All Available Metrics",
+    height: '250px',
+    collapse: false,
+    panels: [
+      panel_all_metrics()
+    ]
+  }
+};
+
+//---------------------------------------------------------------------------------------
+
+
+return function(callback) {
+
+  // Setup some variables
+  var dashboard;
+
+  // Intialize a skeleton with nothing but a rows array and service object
+  dashboard = {
+    rows : [],
+    services : {}
+  };
+
+  // set filter
+  var dashboard_filter = {
+    time: {
+      from: "now-" + arg_from,
+      to: "now"
+    },
+  };
+
+  // define pulldowns
+  pulldowns = [
+    {
+      type: "filtering",
+      collapse: false,
+      notice: false,
+      enable: true
+    },
+    {
+      type: "annotations",
+      enable: false
+    }
+  ];
+
+  dashboard.title = arg_title;
+  dashboard.refresh = arg_refresh;
+  dashboard.editable = true;
+  dashboard.pulldowns = pulldowns;
+  dashboard.services.filter = dashboard_filter;
+
+  $.ajax({
+    method: 'GET',
+    url: '/'
+  })
+  .done(function(result) {
+
+    if ( ! arg_no_help ) {
+      dashboard.rows.push(row_help_text())
+    }
+
+    if ( arg_targets == "" ) {
+      dashboard.rows.push(row_all_metrics())
+    } else {
+      var targets = arg_targets.split(',').map(function(target) { return { "target": target } })
+      dashboard.rows.push(row_custom_metric("Title", targets))
+    }
+
+    // when dashboard is composed call the callback
+    // function and pass the dashboard
+    callback(dashboard);
+  });
+}

--- a/metrics/files/grafana/custom_metrics.js
+++ b/metrics/files/grafana/custom_metrics.js
@@ -57,7 +57,7 @@ function get_all_metrics() {
 function panel_help_text() {
   var help_md = "### How to use this dashboard\n" +
                 "\n" +
-                "This dashboard expects a comma separated list of graphite target paths.\n" +
+                "This dashboard expects a pipe-separated list of graphite target paths.\n" +
                 "\n" +
                 "These will typically need to be URI encoded.\n" +
                 "\n" +
@@ -66,7 +66,7 @@ function panel_help_text() {
                 "Arguments:\n" +
                 "\n" +
                 "* `no_help` -- omit this panel\n" +
-                "* `targets={target1},{target2},...`\n" +
+                "* `targets={target1}|{target2}|...`\n" +
                 "* `refresh={interval}` override default refresh interval of `1min`\n" +
                 ""
 
@@ -217,7 +217,7 @@ return function(callback) {
     if ( arg_targets == "" ) {
       dashboard.rows.push(row_all_metrics())
     } else {
-      var targets = arg_targets.split(',').map(function(target) { return { "target": target } })
+      var targets = arg_targets.split('|').map(function(target) { return { "target": target } })
       dashboard.rows.push(row_custom_metric("Title", targets))
     }
 

--- a/metrics/grafana.sls
+++ b/metrics/grafana.sls
@@ -34,7 +34,7 @@ grafana.git:
     - source: salt://metrics/templates/grafana/config.js
     - user: root
     - group: root
-    - mode: 644 
+    - mode: 644
     - template: jinja
     - require:
       - file: /srv/grafana/application/current
@@ -44,7 +44,7 @@ grafana.git:
     - source: salt://metrics/files/grafana/instance.js
     - user: root
     - group: root
-    - mode: 644 
+    - mode: 644
     - require:
       - file: /srv/grafana/application/current
 
@@ -53,7 +53,16 @@ grafana.git:
     - source: salt://metrics/files/grafana/overview.js
     - user: root
     - group: root
-    - mode: 644 
+    - mode: 644
+    - require:
+      - file: /srv/grafana/application/current
+
+/srv/grafana/application/current/src/app/dashboards/custom_metrics.js:
+  file.managed:
+    - source: salt://metrics/files/grafana/custom_metrics.js
+    - user: root
+    - group: root
+    - mode: 644
     - require:
       - file: /srv/grafana/application/current
 
@@ -62,7 +71,7 @@ grafana.git:
     - source: salt://metrics/files/grafana/monitoring_health.js
     - user: root
     - group: root
-    - mode: 644 
+    - mode: 644
     - require:
       - file: /srv/grafana/application/current
 


### PR DESCRIPTION
The custom_metrics.js dashboard takes a single 'target=xxx' argument
which allows us to specify a comma-separated (individually urlencoded)
list of targets to display in a single graph.

If no target is requested, provides a full list of the available metrics
from index.json