### PR TITLE
Let upstart handle the logging of graphite and carbon daemons.

### DIFF
--- a/metrics/files/graphite/carbon.conf
+++ b/metrics/files/graphite/carbon.conf
@@ -16,7 +16,7 @@ pre-start script
   /srv/graphite/bin/update_whisper_files_if_config_changed {{graphite.data_dir}}
 end script
 
-exec /srv/graphite/bin/carbon-cache.py --debug start >>/var/log/graphite/carbon-supervisor.out 2>>/var/log/graphite/carbon-supervisor.err
+exec /srv/graphite/bin/carbon-cache.py --debug
 
 ## Try to restart up to 10 times within 5 min:
 respawn

--- a/metrics/files/graphite/graphite.conf
+++ b/metrics/files/graphite/graphite.conf
@@ -7,7 +7,7 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 env PATH=/usr/local/bin/:/usr/local/sbin:/bin:/usr/sbin:/usr/bin:/sbin
 setuid graphite
 chdir /srv/graphite/application/current
-exec /srv/graphite/virtualenv/bin/gunicorn graphite.wsgi:application -b unix:///var/run/graphite/graphite.sock >>/var/log/graphite/graphite-supervisor.out 2>>/var/log/graphite/graphite-supervisor.err
+exec /srv/graphite/virtualenv/bin/gunicorn graphite.wsgi:application -b unix:///var/run/graphite/graphite.sock
 
 ## Try to restart up to 10 times within 5 min:
 respawn


### PR DESCRIPTION
This likely means that stdout and stderr will be combined but this is a
better approach as it lets upstart handle rotation, (and means we don'g
have 'supervisor' appear in the log filename, though we could have just
renamed that.)