### PR TITLE
Have all variables in the grafana config file quoted in the same way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased (Version 2.x.0)
+
+* Change quoting requirements on grafana:index pillar value to make it match
+  the style of grafana:elasticsearchUrl and grafana:graphiteUrl (**BREAKING
+  CHANGE**)
+
 # Version 1.11.1
 
 * remove supervisor dependency

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,9 @@ metrics
 Usage
 -----
 
-You shouldn't use this formula directly unless you know what you are doing.  If you want to set up monitoring on your servers you should look at the monitoring formula.
+You shouldn't use this formula directly unless you know what you are doing.  If
+you want to set up monitoring on your servers you should look at the monitoring
+formula.
 
 Install and configure graphite, collectd, bucky and grafana.
 
@@ -17,8 +19,8 @@ So use it only to store host specific metrics.
 
 Secondly, in case you need host independent, aggregated metrics
 i.e. you want to report data from application scaled horizontally behind loadbalancer,
-than use a central metrics endpoint. It's by default located on host: `monitoring.local` and port 8126.
-This functionality is provided by bucky.
+than use a central metrics endpoint. It's by default located on host:
+`monitoring.local` and port 8126.  This functionality is provided by bucky.
 
 
 Collectd exposes
@@ -53,6 +55,44 @@ well with other tools in this formula:
 - overview.js -- overview of all nodes under a graphite 'env' prefix.
 - instance.js -- detailed information about a node
 - monitoring_health.js -- key information about the monitoring server services
+
+Pillar variables
+----------------
+
+- grafana:elasticsearchUrl
+
+  The URL at which the Elasticsearch server can be reached by the client
+  browser. The default is to take the current host:port and replaces 'grafana'
+  part of the hostname with 'elasticsearch'.
+
+- grafana:graphiteUrl
+
+  The URL of the Graphite server to pull data from. Must be reachable by the
+  client browser. The default uses the request host:port and replaces 'grafana'
+  with 'graphite'.
+
+- grafana:index
+
+  The name of the Elasticsearch index to save grafana's dashboards in. Default
+  of 'grafana-dash'
+
+- grafana:default_route
+
+  Dashboard to show when requesting / (what should appear after the '#' fragment). Can be
+  over-ridden on a per client basis with cookies. Default of
+  '/dashboard/script/overview.js'
+
+
+The ``elasticsearchUrl``, ``graphiteUrl`` and ``index`` values are wrapped in double
+quotes in the resulting `.js` file which means you can have JS expressions use
+at runtime so long as you follow this form in your pillar:
+
+.. code-block:: yaml
+    grafana:
+      index: 'grafana-dash_" + window.location.hostname + "'
+
+The important bits are: no opening quote, ending in an open double quote (``+
+"``), and enclosing in single quotes to keep YAML happy.
 
 apparmor
 ========

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,25 @@
 Upgrading between versions
 
+To v2.x.0
+---------
+
+If you have specifed a custom grafana:index pillar key remove the quotes from
+around it in the pillar.
+
+Old style:
+
+```yaml
+grafana:
+  index: '"grafana-dash"'
+```
+
+New style:
+
+```yaml
+grafana:
+  index: 'grafana-dash'
+```
+
 To v1.6.0
 ----------
 

--- a/metrics/map.jinja
+++ b/metrics/map.jinja
@@ -4,7 +4,7 @@
         'elasticsearchUrl': '//"+window.location.hostname.replace(/^grafana/,"elasticsearch")+(window.location.port ? ":" + window.location.port : "")+"',
         'graphiteUrl': '//"+window.location.hostname.replace(/^grafana/,"graphite")+(window.location.port ? ":" + window.location.port : "")+"',
         'default_route': '/dashboard/script/overview.js',
-        'index': '"grafana-dash"',
+        'index': 'grafana-dash',
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('grafana', {})) %}

--- a/metrics/templates/grafana/config.js
+++ b/metrics/templates/grafana/config.js
@@ -49,7 +49,7 @@ function (Settings) {
 
     timezoneOffset: "0000",
 
-    grafana_index: {{ grafana.index }},
+    grafana_index: "{{ grafana.index }}",
 
     panel_names: [
       'text',


### PR DESCRIPTION
This is a backwards incompatible change and for that is slightly annoying but it means our pillars look far more consistent around how you quote.

The old style for the `grafana:index` param was like this (note the single quote inside the double quote):

```yaml
grafana:
  index: '"grafana-dash_" + window.location.hostname'
  elasticsearchUrl: '//"+window.location.hostname.replace(/^grafana/,"elasticsearch")+"',
```

We now have (note the `+ "` at the end)

```yaml
grafana:
  index: 'grafana-dash_" + window.location.hostname + "'
  elasticsearchUrl: '//"+window.location.hostname.replace(/^grafana/,"elasticsearch")+"',
```