### PR TITLE
Add an ability to set `server_name` for the nginx virtual hosts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.0.2
+
+* Add an ability to set `server_name` for the nginx virtual host for
+  both the Graphite and Grafana via a pillar. The default value is
+  set via `map.jinja`.
+
 # Version 2.0.1
 
 * Fix a syntax error in the instance.js dashboard.

--- a/metrics/grafana.sls
+++ b/metrics/grafana.sls
@@ -95,7 +95,7 @@ grafana-download:
     - context:
       appslug: grafana
       is_default: False
-      server_name: 'grafana.*'
+      server_name: {{ grafana.server_name }}
       root_dir: /srv/grafana/current
       index: False
     - watch_in:

--- a/metrics/graphite.sls
+++ b/metrics/graphite.sls
@@ -181,7 +181,7 @@ carbon:
     - context:
       unix_socket: /var/run/graphite/graphite.sock
       appslug: graphite
-      server_name: graphite.*
+      server_name: {{ graphite.server_name }}
       is_default: False
       root_dir: /srv/graphite/data/webapp
       headers:

--- a/metrics/map.jinja
+++ b/metrics/map.jinja
@@ -7,6 +7,7 @@
         'graphiteUrl': '//"+window.location.hostname.replace(/^grafana/,"graphite")+(window.location.port ? ":" + window.location.port : "")+"',
         'default_route': '/dashboard/script/overview.js',
         'index': 'grafana-dash',
+        'server_name': 'grafana.*'
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('grafana', {})) %}
@@ -15,6 +16,7 @@
     'Debian': {
         'secret_key': 'updateme',
         'data_dir': '/srv/graphite/storage',
+        'server_name': 'graphite.*'
     },
     'default': 'Debian',
 }, merge=salt['pillar.get']('graphite',{})) %}


### PR DESCRIPTION
This is concerns both the Graphite and Grafana services.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>