### PR TITLE
Remove `archive.extracted` and replace it with manual steps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.0.4
+
+* Fix. Retire `archive.extracted` in favour of a manual
+  extraction of the tar archive. This is due to an error
+  in Salt, see: https://github.com/saltstack/salt/issues/20485
+
 # Version 2.0.3
 
 * Fix. Add the `x` flag `tar_options` to resolve issue with

--- a/metrics/grafana.sls
+++ b/metrics/grafana.sls
@@ -16,15 +16,25 @@ include:
     - recuse: True
 
 grafana-download:
-  archive.extracted:
-    - name: /srv/grafana
+  file.managed:
+    - name: /tmp/grafana-{{ grafana.version }}.tar.gz
     - source: http://grafanarel.s3.amazonaws.com/grafana-{{ grafana.version }}.tar.gz
     - source_hash: {{ grafana.src_checksum }}
-    - archive_format: tar
-    - tar_options: xz
-    - if_missing: grafana-{{ grafana.version }}/
+    - unless: test -d /srv/grafana/grafana-{{ grafana.version }}
     - require:
       - file: /srv/grafana
+
+grafana-extract:
+  cmd.wait:
+    - name: tar -zxf /tmp/grafana-{{ grafana.version }}.tar.gz -C /srv/grafana
+    - require:
+      - file: /srv/grafana
+    - watch:
+      - file: /tmp/grafana-{{ grafana.version }}.tar.gz
+  file.absent:
+    - name: /tmp/grafana-{{ grafana.version }}.tar.gz
+    - watch:
+      - cmd: grafana-extract
 
 /srv/grafana/current:
   file:


### PR DESCRIPTION
This is because there is a bug in Salt preventing `archive.extracted`
from working when `if_missing` is used, see:

  https://github.com/saltstack/salt/issues/20485

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>