### PR TITLE
Fix bug in carbon upstart script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.0.x
+
+* Fix bug in carbon upstart script
+
 # Version 2.0.4
 
 * Fix. Retire `archive.extracted` in favour of a manual

--- a/metrics/files/graphite/carbon.conf
+++ b/metrics/files/graphite/carbon.conf
@@ -16,7 +16,7 @@ pre-start script
   /srv/graphite/bin/update_whisper_files_if_config_changed {{graphite.data_dir}}
 end script
 
-exec /srv/graphite/bin/carbon-cache.py --debug
+exec /srv/graphite/bin/carbon-cache.py --debug start
 
 ## Try to restart up to 10 times within 5 min:
 respawn


### PR DESCRIPTION
I introduced this in commit 5f017fc "Let upstart handle the logging of
graphite and carbon daemons." and I'm not sure how it hasn't bitten
anyone else since.

The change in that commit was:

```diff
@@ -16,7 +16,7 @@ pre-start script
   /srv/graphite/bin/update_whisper_files_if_config_changed {{graphite.data_dir}}
 end script
 
-exec /srv/graphite/bin/carbon-cache.py --debug start >>/var/log/graphite/carbon-supervisor.out 2>>/var/log/graphite/carbon-supervisor.err
+exec /srv/graphite/bin/carbon-cache.py --debug
 
 ## Try to restart up to 10 times within 5 min:
respawn
```

I removed the `start` argument and shouldn't have. This PR just adds it back.