### PR TITLE
Check that an important file exists, not just the flag file.

### DIFF
--- a/metrics/graphite.sls
+++ b/metrics/graphite.sls
@@ -113,7 +113,7 @@ graphite_seed:
     - script
     - source: salt://metrics/files/graphite/graphite_seed.sh
     - cwd: /srv/graphite/application/current
-    - unless: 'test -e /srv/graphite/.graphite_seed.done'
+    - unless: 'test -e /srv/graphite/.graphite_seed.done -a -f {{ graphite.data_dir }}/graphite.db'
     - user: graphite
     - require:
       - user: graphite


### PR DESCRIPTION
This doesn't affect many people, but in test envs I've been blowing away
everything in the directory and had to manually remove the seed.done
flag.

This fixes it so that if the DB is removed it will run itself
